### PR TITLE
Add github action to automatically build installables for macos and windows 🐙

### DIFF
--- a/.github/workflows/python-installer.yml
+++ b/.github/workflows/python-installer.yml
@@ -21,3 +21,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         path: dist/*
+        name: dist-${{ matrix.platform }}

--- a/.github/workflows/python-installer.yml
+++ b/.github/workflows/python-installer.yml
@@ -1,0 +1,23 @@
+# adapted from here: https://github.com/pyinstaller/pyinstaller/issues/6296
+# build a windows and python installable
+on:
+  push:
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest','macos-latest']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - run: pip install pyinstaller
+    - run: pyinstaller src/openape.py
+    # Optionally verify that it works (provided that it does not need user interaction)
+    #- run: ./dist/your-code/your-code
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*

--- a/.github/workflows/python-installer.yml
+++ b/.github/workflows/python-installer.yml
@@ -21,4 +21,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         path: dist/*
-        name: dist-${{ matrix.platform }}
+        name: dist-${{ matrix.os}}


### PR DESCRIPTION
Thanks for your work :100:.

This PR adds support to automatically create builds for macos and windows using `pyinstaller`.

The files are saved as artifacts in  the workflow run. For the artifacts see:
https://github.com/KarelZe/RestrictionOfCircularDNA/suites/9799422254/artifacts/471417392
For the workflow run see:
https://github.com/KarelZe/RestrictionOfCircularDNA/actions/runs/3670070443

I assumed `src/openape.py ` is accessed. The workflow runs, whenever code is added. You can tweak the behaviour to your liking e. g., when tags are created, use for certain branches. See:
https://docs.github.com/de/actions/using-workflows/workflow-syntax-for-github-actions
for more details.